### PR TITLE
Allow express mode on  Slamtec RPLIDAR A1M8 

### DIFF
--- a/rplidar.py
+++ b/rplidar.py
@@ -399,7 +399,7 @@ class RPLidar(object):
             if self.scanning[2] == 'express':
                 if self.express_trame == 32:
                     self.express_trame = 0
-                    if not self.express_data:
+                    if not self.express_data or type(self.express_data) == bool:
                         self.logger.debug('reading first time bytes')
                         self.express_data = ExpressPacket.from_string(
                                             self._read_response(dsize))


### PR DESCRIPTION
Receiving start_angle errors when using a Slamtec RPLIDAR A1M8 on Windows/Python and attemping to set scan_mode to 'express'. For some reason (I'm new to this) self.express_data is being set to bool. Added to the "if not self.express_data" check to see if it's bool. Works fine now in express mode.